### PR TITLE
Add CITATION.cff with software and paper references

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,69 @@
+cff-version: 1.2.0
+message: >-
+  Please cite TaxonDNA using the Zenodo reference below. If you used
+  SpeciesIdentifier, also cite Meier et al. (2006); if you used
+  SequenceMatrix, also cite Vaidya et al. (2011). See references below.
+type: software
+title: TaxonDNA
+abstract: >-
+  A taxonomy-aware DNA sequence processing toolkit providing three desktop
+  applications: SpeciesIdentifier (DNA barcoding and species identification),
+  SequenceMatrix (multi-gene dataset concatenation), and GenBankExplorer
+  (GenBank file browser).
+authors:
+  - family-names: Vaidya
+    given-names: Gaurav
+    email: gaurav@ggvaidya.com
+    orcid: https://orcid.org/0000-0003-0587-0454
+version: 1.11-SNAPSHOT
+date-released: "2025-03-11"
+license: LGPL-2.0-or-later
+repository-code: https://github.com/gaurav/taxondna
+doi: 10.5281/zenodo.14994608
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.14994608
+    description: Zenodo archive of TaxonDNA
+references:
+  - type: article
+    title: >-
+      DNA Barcoding and Taxonomy in Diptera: a Tale of High Intraspecific
+      Variability and Low Identification Success
+    notes: >-
+      Cite this when using SpeciesIdentifier.
+    authors:
+      - family-names: Meier
+        given-names: Rudolf
+      - family-names: Kwong
+        given-names: Sabrina
+      - family-names: Vaidya
+        given-names: Gaurav
+      - family-names: Ng
+        given-names: Peter K. L.
+    journal: Systematic Biology
+    volume: 55
+    issue: 5
+    start: 715
+    end: 728
+    year: 2006
+    doi: 10.1080/10635150600969864
+  - type: article
+    title: >-
+      SequenceMatrix: concatenation software for the fast assembly of
+      multi-gene datasets with character set and codon information
+    notes: >-
+      Cite this when using SequenceMatrix.
+    authors:
+      - family-names: Vaidya
+        given-names: Gaurav
+      - family-names: Lohman
+        given-names: David J.
+      - family-names: Meier
+        given-names: Rudolf
+    journal: Cladistics
+    volume: 27
+    issue: 2
+    start: 171
+    end: 180
+    year: 2011
+    doi: 10.1111/j.1096-0031.2010.00329.x

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,16 @@ abstract: >-
 authors:
   - family-names: Vaidya
     given-names: Gaurav
+    alias: gaurav
     email: gaurav@ggvaidya.com
     orcid: https://orcid.org/0000-0003-0587-0454
+  - family-names: Lohman
+    given-names: David J.
+    alias: djlohman
+    orcid: https://orcid.org/0000-0002-0689-2906
+  - family-names: Meier
+    given-names: Rudolf
+    orcid: https://orcid.org/0000-0002-4452-2885
 version: 1.11-SNAPSHOT
 date-released: "2025-03-11"
 license: LGPL-2.0-or-later
@@ -34,10 +42,13 @@ references:
     authors:
       - family-names: Meier
         given-names: Rudolf
+        orcid: https://orcid.org/0000-0002-4452-2885
       - family-names: Kwong
         given-names: Sabrina
       - family-names: Vaidya
         given-names: Gaurav
+        alias: gaurav
+        orcid: https://orcid.org/0000-0003-0587-0454
       - family-names: Ng
         given-names: Peter K. L.
     journal: Systematic Biology
@@ -56,10 +67,14 @@ references:
     authors:
       - family-names: Vaidya
         given-names: Gaurav
+        alias: gaurav
+        orcid: https://orcid.org/0000-0003-0587-0454
       - family-names: Lohman
         given-names: David J.
+        orcid: https://orcid.org/0000-0002-0689-2906
       - family-names: Meier
         given-names: Rudolf
+        orcid: https://orcid.org/0000-0002-4452-2885
     journal: Cladistics
     volume: 27
     issue: 2


### PR DESCRIPTION
Cites the Zenodo archive as the primary software reference, with both companion papers (Meier et al. 2006 for SpeciesIdentifier, Vaidya et al. 2011 for SequenceMatrix) listed as references with notes directing users to the appropriate paper for each tool.